### PR TITLE
Fixes

### DIFF
--- a/example.rkt
+++ b/example.rkt
@@ -3,6 +3,8 @@
 (require "libnotify.rkt"
          pict)
 
+(init-libnotify)
+
 (define note
   (new notification%
        [summary "Hello World!"]

--- a/exception.rkt
+++ b/exception.rkt
@@ -1,0 +1,6 @@
+#lang racket/base
+(provide (struct-out exn:fail:libnotify) raise-libnotify-error)
+
+(struct exn:fail:libnotify exn:fail ())
+(define (raise-libnotify-error msg)
+  (raise (exn:fail:libnotify msg (current-continuation-marks))))

--- a/ffi-test.rkt
+++ b/ffi-test.rkt
@@ -11,3 +11,5 @@
 (sleep 3)
 
 (notification-close notification)
+
+(notify-uninit)

--- a/ffi.rkt
+++ b/ffi.rkt
@@ -2,9 +2,10 @@
 
 (require ffi/unsafe
          ffi/unsafe/define
+         ffi/unsafe/alloc
          "exception.rkt")
 
-(provide notification-new
+(provide (rename-out (notification-new/auto-free notification-new))
          notification-update
          notification-show
          notification-set-app-name
@@ -45,7 +46,6 @@
   ([domain _uint32]
    [code _int]
    [message _string]))
-
 (define-glib free-GError (_fun _GError -> _void) #:c-id g_error_free)
 
 (define _NotifyUrgency
@@ -55,6 +55,9 @@
                (_fun _string _string _string
                      -> _NotifyNotification)
                #:c-id notify_notification_new)
+;; Its result must not be deallocated manually
+(define notification-new/auto-free
+  ((allocator free) notification-new))
 
 (define-notify notification-update
                (_fun _NotifyNotification _string _string _string

--- a/ffi.rkt
+++ b/ffi.rkt
@@ -33,7 +33,7 @@
 (define-cpointer-type _NotifyNotification)
 
 (define-cstruct _GError
-  ([domain _int]
+  ([domain _uint32]
    [code _int]
    [message _string]))
 

--- a/ffi.rkt
+++ b/ffi.rkt
@@ -58,7 +58,8 @@
 
 (define-notify notification-update
                (_fun _NotifyNotification _string _string _string
-                     -> _bool)
+                     -> (ret : _bool) ->
+                     (or ret (raise-libnotify-error "Fail to update the notification")))
                #:c-id notify_notification_update)
 
 (define-notify notification-show

--- a/ffi.rkt
+++ b/ffi.rkt
@@ -100,7 +100,8 @@
                #:c-id notify_notification_close)
 
 (define-notify notify-init
-               (_fun _string -> _bool)
+               (_fun _string -> (ret : _bool) ->
+                     (or ret (raise-libnotify-error "Fail to init libnotify")))
                #:c-id notify_init)
 
 (define-notify notify-uninit

--- a/ffi.rkt
+++ b/ffi.rkt
@@ -4,6 +4,7 @@
          ffi/unsafe/define)
 
 (provide GError-message
+         _GError
          notification-new
          notification-update
          notification-show

--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,5 @@
 #lang info
+(define collection "libnotify")
 
 (define deps '("base" "draw-lib"))
 (define build-deps '("scribble-lib" "racket-doc" "draw-doc"))

--- a/libnotify.rkt
+++ b/libnotify.rkt
@@ -22,7 +22,7 @@
 
 (define (init-libnotify (name "Racket"))
   (notify-init name)
-  ;; Uninit the library before exiting
+  ;; Control the finalization through current-plumber parameter
   (plumber-add-flush! (current-plumber) (lambda (hd) (notify-uninit))))
 
 (define notification%

--- a/libnotify.rkt
+++ b/libnotify.rkt
@@ -17,9 +17,13 @@
                   [urgency (or/c 'low 'normal 'critical)]
                   [category (or/c string? #f)])
             [show (->m any)]
-            [close (->m any)])]))
+            [close (->m any)])]
+          [init-libnotify (->* () (string?) any)]))
 
-(define initialized? #f)
+(define (init-libnotify (name "Racket"))
+  (notify-init name)
+  ;; Uninit the library before exiting
+  (plumber-add-flush! (current-plumber) (lambda (hd) (notify-uninit))))
 
 (define notification%
   (class object%
@@ -30,11 +34,6 @@
           [(_timeout timeout) #f]
           [urgency 'normal]
           [category #f])
-
-    ;; Initialize libnotify unless it already has been
-    ;; unlikely to work if the module is instantiated multiple times
-    (unless initialized?
-      (notify-init "Racket"))
 
     (define icon-path-arg
       (cond [(path? icon) (path->string icon)]

--- a/libnotify.rkt
+++ b/libnotify.rkt
@@ -77,10 +77,10 @@
              (void)]
             [ok? (void)]
             [(not ok?)
-             (raise-libnotify-error (GError-message err))]))
+             (raise-libnotify-error (GError-message (ptr-ref err _GError)))]))
 
     (define/public (close)
       (define-values (ok? err)
         (notification-close handle))
       (unless ok?
-        (raise-libnotify-error (GError-message err))))))
+        (raise-libnotify-error (GError-message (ptr-ref err _GError)))))))

--- a/libnotify.rkt
+++ b/libnotify.rkt
@@ -17,15 +17,9 @@
                   [urgency (or/c 'low 'normal 'critical)]
                   [category (or/c string? #f)])
             [show (->m any)]
-            [close (->m any)])])
-         (struct-out exn:fail:libnotify))
-
-(struct exn:fail:libnotify exn:fail ())
+            [close (->m any)])]))
 
 (define initialized? #f)
-
-(define (raise-libnotify-error msg)
-  (raise (exn:fail:libnotify msg (current-continuation-marks))))
 
 (define notification%
   (class object%
@@ -65,22 +59,13 @@
     (define timeout-thunk
       (λ () (sleep timeout) (close)))
 
-    ;; See https://developer.gnome.org/notification-spec/ (Table 2)
+    ;; See https://developer-old.gnome.org/notification-spec/ (Table 2)
     (when category
       (notification-set-category handle category))
 
     (define/public (show)
-      (define-values (ok? err)
-        (notification-show handle))
-      (cond [(and ok? timeout)
-             (thread timeout-thunk)
-             (void)]
-            [ok? (void)]
-            [(not ok?)
-             (raise-libnotify-error (GError-message (ptr-ref err _GError)))]))
+      (notification-show handle)
+      (cond [timeout (thread timeout-thunk) (void)]))
 
     (define/public (close)
-      (define-values (ok? err)
-        (notification-close handle))
-      (unless ok?
-        (raise-libnotify-error (GError-message (ptr-ref err _GError)))))))
+      (notification-close handle))))

--- a/libnotify.scrbl
+++ b/libnotify.scrbl
@@ -55,3 +55,9 @@ library which provides support for the desktop notifications API.
   An exception structure type for reporting errors from the underlying
   libnotify library.
 }
+
+@defproc[(init-libnotify (name string? "Racket")) any]{
+  Initializes the library and registers the uninitialization procedure
+  as a @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{flush callback}
+  in @racket[(current-plumber)].
+}

--- a/main.rkt
+++ b/main.rkt
@@ -1,4 +1,4 @@
 #lang racket/base
 
-(require "libnotify.rkt")
-(provide (all-from-out "libnotify.rkt"))
+(require "libnotify.rkt" "exception.rkt")
+(provide (all-from-out "libnotify.rkt" "exception.rkt"))


### PR DESCRIPTION
1. Fix the type of GError structure.
2. Handle errors properly.
3. Free GError instances.
4. Add a collection name in the info.rkt.